### PR TITLE
update landing page

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -102,7 +102,7 @@
         "value": "GB"
       },
       "access": {
-        "landingPage": "https://registeredpreventad.loris.ca",
+        "landingPage": "https://www.centre-stopad.com/en/",
         "authorizations": [
           {
             "value": "private"


### PR DESCRIPTION
This PR updates the PreventAD landing page to https://www.centre-stopad.com/en/.